### PR TITLE
add @:keep to refresh() functions to prevent DCE

### DIFF
--- a/src/coconut/ds/Collection.hx
+++ b/src/coconut/ds/Collection.hx
@@ -96,7 +96,7 @@ class IntCollection<RawData, Item> implements coconut.data.Model implements ICol
 	}
 	@:constant var map:Dict<Int, Item> = new Dict(createItem.bind(_, None));
 	
-	public function refresh(cache = None) {
+	@:keep public function refresh(cache = None) {
 		this.cache = cache;
 		revision++;
 	}
@@ -124,7 +124,7 @@ class StringCollection<RawData, Item> implements coconut.data.Model implements I
 	}
 	@:constant var map:Dict<String, Item> = new Dict(createItem.bind(_, None));
 	
-	public function refresh(cache = None) {
+	@:keep public function refresh(cache = None) {
 		this.cache = cache;
 		revision++;
 	}
@@ -152,7 +152,7 @@ class EnumValueCollection<RawData, Item> implements coconut.data.Model implement
 	}
 	@:constant var map:Dict<EnumValue, Item> = new Dict(createItem.bind(_, None));
 	
-	public function refresh(cache = None) {
+	@:keep public function refresh(cache = None) {
 		this.cache = cache;
 		revision++;
 	}

--- a/src/coconut/ds/SubCollection.hx
+++ b/src/coconut/ds/SubCollection.hx
@@ -46,7 +46,7 @@ class SubCollection<Key, RawData, Item> implements coconut.data.Model implements
 		return parent.sub(fetch);
 	}
 	
-	public function refresh(cache = None) {
+    @:keep public function refresh(cache = None) {
 		this.cache = cache;
 		revision++;
 	}

--- a/src/coconut/ds/Updatable.hx
+++ b/src/coconut/ds/Updatable.hx
@@ -16,7 +16,7 @@ class Updatable<Content, Patch> implements coconut.data.Model {
 		}
 	}
 	
-	public function refresh(cache = None) {
+	@:keep public function refresh(cache = None) {
 		this.cache = cache;
 		revision++;
 	}


### PR DESCRIPTION
as discussed on gitter without `@:keep` in some cases `refresh()` gets DCE-ed with `-dce full`.

For reference, error at runtime was `TypeError: sub.refresh is not a function`.